### PR TITLE
Removed PSSN usage for FWHM

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,13 @@
 Version History
 ##################
 
+.. _lsst.ts.ofc-2.1.2:
+
+v2.1.2
+======
+
+* Substituted pssn to fwhm for gain calculations.
+
 .. _lsst.ts.ofc-2.1.1:
 
 v2.1.1

--- a/python/lsst/ts/ofc/ofc_controller.py
+++ b/python/lsst/ts/ofc/ofc_controller.py
@@ -169,41 +169,6 @@ class OFCController:
         else:
             raise ValueError(f"Gain must be in the range of [0, 1]. Got {value}.")
 
-    def effective_fwhm_g4(self, pssn, field_idx):
-        """Calculate the effective FWHM by Gaussian quadrature.
-
-        FWHM: Full width at half maximum.
-        FWHM = eta * FWHM_{atm} * sqrt(1/PSSN -1).
-        Effective GQFWHM = sum_{i} (w_{i}* FWHM_{i}).
-
-        Parameters
-        ----------
-        pssn : `numpy.ndarray` or `list`
-            Normalized point source sensitivity (PSSN).
-        fieldIdx : `numpy.ndarray` or `list` of `int`
-            Field index array.
-
-        Returns
-        -------
-        `float`
-            Effective FWHM in arcsec by Gaussain quadrature.
-
-        Raises
-        ------
-        ValueError
-            Input values are unphysical.
-        """
-
-        # Normalized image quality weight
-        n_imqw = self.ofc_data.normalized_image_quality_weight[field_idx]
-        fwhm = self.ETA * self.FWHM_ATM * np.sqrt(1.0 / np.array(pssn) - 1.0)
-        fwhm_gq = np.sum(n_imqw * fwhm)
-
-        if np.isnan(fwhm_gq) or np.isinf(fwhm_gq):
-            raise ValueError("Input values are unphysical.")
-
-        return fwhm_gq
-
     def authority(self):
         """Compute the authority of the system.
 
@@ -410,25 +375,3 @@ class OFCController:
         )
 
         return uk.ravel()
-
-    def fwhm_to_pssn(self, fwhm):
-        """Convert the FWHM data to PSSN.
-
-        Take the array of FWHM values (nominally 1 per CCD) and convert
-        it to PSSN (nominally 1 per CCD).
-
-        Parameters
-        ----------
-        fwhm : `numpy.ndarray[x]`
-            An array of FWHM values with sensor information.
-
-        Returns
-        -------
-        pssn : `numpy.ndarray[y]`
-            An array of PSSN values.
-        """
-
-        denominator = self.ETA * self.FWHM_ATM
-        pssn = 1.0 / ((fwhm / denominator) ** 2 + 1.0)
-
-        return pssn

--- a/tests/test_ofc.py
+++ b/tests/test_ofc.py
@@ -46,28 +46,12 @@ class TestOFC(unittest.TestCase):
 
         self.assertTrue(np.all(self.ofc.lv_dof == 0))
 
-    def test_pssn_data(self):
-        self.assertTrue("sensor_id" in self.ofc.pssn_data)
-        self.assertTrue("pssn" in self.ofc.pssn_data)
-        self.assertTrue(self.ofc.pssn_data["sensor_id"] is None)
-        self.assertTrue(self.ofc.pssn_data["pssn"] is None)
-
     def test_set_fwhm_data(self):
         fwhm_values = np.ones((5, 19)) * 0.2
-        sensor_id = np.arange(5)
 
-        self.ofc.set_fwhm_data(fwhm_values, sensor_id)
+        self.ofc.set_fwhm_data(fwhm_values)
 
-        self.assertTrue(np.all(sensor_id == self.ofc.pssn_data["sensor_id"]))
-        self.assertAlmostEqual(self.ofc.pssn_data["pssn"][0], 0.9139012, places=6)
-
-    def test_set_fwhm_data_fails(self):
-        # Passing fwhm_values with 4 columns instead of 5
-        fwhm_values = np.ones((4, 19)) * 0.2
-        sensor_id = np.arange(5)
-
-        with self.assertRaises(RuntimeError):
-            self.ofc.set_fwhm_data(fwhm_values, sensor_id)
+        assert np.allclose(self.ofc.fwhm_data, fwhm_values)
 
     def test_reset(self):
         dof = np.ones_like(self.ofc.ofc_controller.dof_state)
@@ -94,25 +78,24 @@ class TestOFC(unittest.TestCase):
         self.assertEqual(len(self.ofc.lv_dof), 50)
         self.assertEqual(np.sum(np.abs(self.ofc.lv_dof)), 0)
 
-    def test_set_pssn_gain_unconfigured(self):
+    def test_set_gain_from_fwhm_unconfigured(self):
         with self.assertRaises(RuntimeError):
-            self.ofc.set_pssn_gain()
+            self.ofc.set_gain_from_fwhm()
 
-    def test_set_pssn_gain(self):
+    def test_set_gain_from_fwhm(self):
         fwhm_values = np.ones((5, 19)) * 0.2
-        sensor_id = np.arange(5)
 
-        self.ofc.set_fwhm_data(fwhm_values, sensor_id)
+        self.ofc.set_fwhm_data(fwhm_values)
 
-        self.ofc.set_pssn_gain()
+        self.ofc.set_gain_from_fwhm()
 
         self.assertTrue(self.ofc.ofc_controller.gain, self.ofc.default_gain)
 
         fwhm_values = np.ones((5, 19))
 
-        self.ofc.set_fwhm_data(fwhm_values, sensor_id)
+        self.ofc.set_fwhm_data(fwhm_values)
 
-        self.ofc.set_pssn_gain()
+        self.ofc.set_gain_from_fwhm()
 
         self.assertTrue(self.ofc.ofc_controller.gain, 1.0)
 


### PR DESCRIPTION
This PR removes calculations of PSSN that weren't actually used. Up until now, we were passing the FWHM values to calculate the PSSN values, and we would then calculate the FWHM values back from the PSSN to obtain the gain. This PR removes the PSSN completely from this repository as it is not needed. Ts_imsim still stores the values of PSSN but it has its own function to compute it. 

Additionally, I removed the usage of image quality weight, because it was only used to do an average, both in the case of `lsstfam`, in which all the points have the same weight, and the case of `lsst` in which case we only use the four corners to set the gain and we give them an equal gain.