### PR TITLE
Add PID option to OFC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ pytest_session.txt
 .mypy.ini
 .clang-format
 .ruff.toml
+towncrier.toml

--- a/doc/developer-guide/control-algorithm/ca-in-ofc.rst
+++ b/doc/developer-guide/control-algorithm/ca-in-ofc.rst
@@ -30,7 +30,11 @@ The solution is:
 
 where :math:`\vec{x}_{k}` is the least norm solution of optical state.
 
-To evaluate :math:`\vec{u}`, the cost function (:math:`J(\vec{u})`) at time :math:`k+1` is defined to be:
+
+Optimal Integral Controller (OIC)
+==================================
+
+To evaluate :math:`\vec{u}`, the OIC approach uses a cost function (:math:`J(\vec{u})`) at time :math:`k+1` defined to be:
 
 .. math::
 
@@ -151,3 +155,10 @@ x00
 
 For the feedback control, instead of sending the full correction, it is usually to sent a ratio of offset.
 So the final correction will be :math:`g\vec{u}` instead of :math:`\vec{u}`.
+
+
+Proportional-Integral-Derivative Controller (PID)
+===================================================
+
+The PID controller is a feedback control loop that calculates the offset of DOF based on the error between the desired setpoint and the estimated optical state. 
+This is a standard controller that works well when using a reduced basis of DOF where the degenerate combinations of Degrees of Freedom have been removed.

--- a/doc/developer-guide/developer-guide.rst
+++ b/doc/developer-guide/developer-guide.rst
@@ -19,7 +19,8 @@ Important classes:
   This includes reading and storing data from files and higher level data manipulation.
 * :py:class:`SensitivityMatrix <lsst.ts.ofc.SensitivityMatrix>` calculates the sensitivity matrix at the given sensors and camera rotation angle.
 * :py:class:`StateEstimator <lsst.ts.ofc.StateEstimator>` contains facilities to estimate the state of the system.
-* :py:class:`OFCController <lsst.ts.ofc.OFCController>` calculates the degrees of freedom (DoF) offset by minimizing the cost function.
+* :py:class:`OICController <lsst.ts.ofc.OICController>` Optimal Integral Controller that calculates the degrees of freedom (DoF) offset by minimizing the cost function.
+* :py:class:`PIDController <lsst.ts.ofc.PIDController>` Proportional-Integral-Derivative Controller that calculates the degrees of freedom (DoF) offset with gains.
 * :py:class:`OFC <lsst.ts.ofc.OFC>` is the main class of the system, responsible for managing the conversion of wavefront errors into corrections.
 
 .. _python data class: https://docs.python.org/3.8/library/dataclasses.html
@@ -38,7 +39,7 @@ Control Algorithm
 
     control-algorithm/*
 
-For more additional details about the algorithm see [Angeli2014]_, [Angeli2016a]_, [Angeli2016b]_ and [Xin2021]_.
+For more additional details about the algorithm see [Angeli2014]_, [Angeli2016a]_, [Angeli2016b]_, [MegiasHomar2024]_ and [Xin2021]_.
 
 Python API reference
 ====================
@@ -67,5 +68,7 @@ References
 .. [Angeli2016a] Angeli, George Z. et al., *An integrated modeling framework for the Large Synoptic Survey Telescope (LSST).* `Proc. SPIE 9911, Modeling, Systems Engineering, and Project Management for Astronomy VI, 991118 (2016). <https://doi.org/10.1117/12.2234078>`_
 
 .. [Angeli2016b] Angeli, George Z. and Xin, Bo, *Normalized Point Source Sensitivity for LSST.* `document-17242. <https://docushare.lsst.org/docushare/dsweb/Get/Document-17242>`_
+
+.. [MegiasHomar2024] Megias Homar, G., et al., *The Active Optics System on the Vera C. Rubin Observatory: Optimal Control of Degeneracy Among the Large Number of Degrees of Freedom* `arXiv (2024) <https://arxiv.org/abs/2406.04656>`_
 
 .. [Xin2021] Xin, Bo, *SITCOMTN-003: Coordinate Transformations within the Rubin Active Optics System.* `sticomtn-003 <https://sitcomtn-003.lsst.io>`_

--- a/doc/uml/ofc_class.mmd
+++ b/doc/uml/ofc_class.mmd
@@ -6,12 +6,15 @@ namespace ofc_data {
 
 class OFC
 StateEstimator *-- OFCData
-OFCController *-- OFCData
-OFCController "1" *-- "2" BendModeToForce
+BaseController *-- OFCData
+OICController "1" *-- "2" BendModeToForce
 BendModeToForce *-- OFCData
 OFC *-- OFCData
 OFC *-- SensitivityMatrix
 OFC *-- StateEstimator
-OFC *-- OFCController
+OFC *-- OICController
+OFC *-- PIDController
 OFC ..> Correction
 BaseOFCData <|-- OFCData
+BaseController <|-- OICController
+BaseController <|-- PIDController

--- a/doc/user-guide/user-guide.rst
+++ b/doc/user-guide/user-guide.rst
@@ -44,7 +44,7 @@ The following provides an example of how one would use :py:class:`OFC <lsst.ts.o
 
   # get corrections from ofc
   m2_hex, cam_hex, m1m3, m2 = ofc.calculate_corrections(
-      wfe=wfe, sensor_names=sensor_names, filter_name="", gain=1.0, rotation_angle=0.0
+      wfe=wfe, sensor_names=sensor_names, filter_name="", rotation_angle=0.0
   )
 
   # Check the output
@@ -95,7 +95,7 @@ This can be done with the following:
 
   # get corrections from ofc
   m2_hex, cam_hex, m1m3, m2 = ofc.calculate_corrections(
-      wfe=wfe, sensor_names=sensor_names, filter_name="R", gain=1.0, rotation_angle=0.0
+      wfe=wfe, sensor_names=sensor_names, filter_name="R", rotation_angle=0.0
   )
 
   # The corrections now should be all zeros
@@ -132,7 +132,7 @@ For instance, one can disable operations will all components except the Camera H
 
   # get corrections from ofc
   m2_hex, cam_hex, m1m3, m2 = ofc.calculate_corrections(
-      wfe=wfe, sensor_names=sensor_names, filter_name="R", gain=1.0, rotation_angle=0.0
+      wfe=wfe, sensor_names=sensor_names, filter_name="R", rotation_angle=0.0
   )
 
   print(cam_hex)
@@ -173,6 +173,8 @@ The basic structure of a configuration directory is as follows:
   │   └── rotMatM2.yaml
   ├── configurations
   │   ├── comcam.yaml
+  │   ├── pid_controller.yaml
+  │   ├── oic_controller.yaml
   │   └── lsst.yaml
   ├── image_quality_weights
   │   ├── comcam_weights.yaml
@@ -276,3 +278,7 @@ Additionally, the directory includes three additional files corresponding to the
   - ``lsst_gaussian_quadrature_weights.yaml``; weighting ratio of image quality used in the Q matrix in cost function.
   - ``lsst_gaussian_quadrature_points.yaml``; mapping between the sensor name and sensor field position.
   - ``lsst_gaussian_quadrature_y2.yaml``; the wavefront error correction between the central raft and corner wavefront sensor.
+
+Finally, there are also different configurations for the controller. These configurations can be modified to try different gains.
+  - ``pid_controller.yaml``; configuration file for the PID controller.
+  - ``oic_controller.yaml``; configuration file for the OIC controller.

--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,15 @@
 Version History
 ##################
 
+.. _lsst.ts.ofc-3.2.0:
+
+v3.2.0
+======
+
+* Add PIDController as alternative control strategy.
+* Move current control strategy to OICController (optimal integral controller).
+* Add PID option to OICController output.
+
 .. _lsst.ts.ofc-3.1.3:
 
 v3.1.3

--- a/policy/configurations/oic_controller.yaml
+++ b/policy/configurations/oic_controller.yaml
@@ -1,0 +1,32 @@
+# Description: Optimal Integral Controller (OIC) configuration file
+#
+# Name: OIC
+# xref is the reference to the controller, it can be ['x0', 'x00', '0']
+# kp is the proportional gain
+# ki is the integral gain defined as ki = kp*T/T_i
+# kd is the derivative gain defined as kd = kp*T_d/T
+# For more details on the controller gains and the values of T, T_i, and T_d, 
+# please refer to the report https://www.betzler.physik.uni-osnabrueck.de/Manuskripte/Elektronik-Praktikum/p3/doc2558.pdf
+# derivative_filter_coeff is the coefficient of the derivative filter
+# setpoint is the setpoint for each degree of freedom (array of 50 elements)
+
+description: Optimal Integral Controller (OIC)
+
+name: OIC
+xref: x00 
+kp: 1.0
+ki: 0
+kd: 0
+derivative_filter_coeff: 1.0
+setpoint: [
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0
+]

--- a/policy/configurations/pid_controller.yaml
+++ b/policy/configurations/pid_controller.yaml
@@ -1,0 +1,28 @@
+# Description: Proportional-Integral-Derivative Controller (PID) configuration file
+#
+# Name: PID
+# kp is the proportional gain
+# ki is the integral gain defined as ki = kp*T/T_i
+# kd is the derivative gain defined as kd = kp*T_d/T
+# derivative_filter_coeff is the coefficient of the derivative filter
+# setpoint is the setpoint for each degree of freedom (array of 50 elements)
+
+description: Proportional-Integral-Derivative Controller
+
+name: PID
+kp: 0.8
+ki: 0.1
+kd: 0.1
+derivative_filter_coeff: 1.0
+setpoint: [
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0, 
+  0.0, 0.0, 0.0, 0.0, 0.0
+]

--- a/python/lsst/ts/ofc/__init__.py
+++ b/python/lsst/ts/ofc/__init__.py
@@ -29,7 +29,7 @@ except ModuleNotFoundError:
 from .bend_mode_to_force import *
 from .sensitivity_matrix import *
 from .state_estimator import *
-from .ofc_controller import *
 from .correction import *
-from .ofc import *
 from .ofc_data import OFCData
+from .ofc import *
+from .controllers import *

--- a/python/lsst/ts/ofc/controllers/__init__.py
+++ b/python/lsst/ts/ofc/controllers/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# This file is part of ts_ofc.
+#
+# Developed for Vera Rubin Observatory.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from .base_controller import *
+from .oic_controller import *
+from .pid_controller import *

--- a/python/lsst/ts/ofc/controllers/base_controller.py
+++ b/python/lsst/ts/ofc/controllers/base_controller.py
@@ -1,0 +1,383 @@
+# This file is part of ts_ofc.
+#
+# Developed for Vera Rubin Observatory.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+
+import numpy as np
+
+from .. import OFCData
+
+__all__ = ["BaseController"]
+
+
+# TODO: DM-45103 Add saturator once bending mode limits are determined.
+class BaseController:
+    """Base Controller.
+
+    This class is the base class for all the controllers.
+    This class is mainly used to determine the offset (`uk`) of degree of
+    freedom (DOF) at time `k+1` based on the wavefront error (`yk`) at time
+    `k`.
+
+    Parameters
+    ----------
+    ofc_data : `OFCData`
+        OFC Data.
+    log : `logging.Logger` or `None`
+        Optional logging class to be used for logging operations. If `None`,
+        creates a new logger.
+
+    Attributes
+    ----------
+    dof_state : `np.array`
+        State of telescope in the basis of degrees of freedom.
+    dof_state0 : `np.array`
+        Initial state of telescope in the basis of degrees of freedom.
+    integral : `np.array`
+        Integral of the error.
+    kp : `float`
+        Proportional gain.
+    ki : `float`
+        Integral gain.
+    kd : `float`
+        Derivative gain.
+    log : `logging.Logger`
+        Logger class used for logging operations.
+    ofc_data : `OFCData`
+        OFC data.
+    previous_error : `np.array`
+        Previous error.
+    pssn_data : `dict`
+        PSSN data.
+    setpoint : `np.array`
+        Setpoint for the PID controller.
+    """
+
+    # Eta in FWHM calculation.
+    ETA = 1.086
+
+    # FWHM in atmosphere.
+    FWHM_ATM = 0.6
+
+    def __init__(self, ofc_data: OFCData, log: logging.Logger | None = None) -> None:
+        if log is None:
+            self.log = logging.getLogger(type(self).__name__)
+        else:
+            self.log = log.getChild(type(self).__name__)
+
+        # Set OFC data
+        self.ofc_data = ofc_data
+
+        # Set gains and setpoint
+        self._kp = self.ofc_data.controller["kp"]
+        self._ki = self.ofc_data.controller["ki"]
+        self._kd = self.ofc_data.controller["kd"]
+        self._derivative_filter_coeff = self.ofc_data.controller[
+            "derivative_filter_coeff"
+        ]
+        self.setpoint = np.array(self.ofc_data.controller["setpoint"])
+
+        # Set initial state
+        self.dof_state0 = np.zeros(len(self.ofc_data.dof_idx))
+
+        for comp in self.ofc_data.comp_dof_idx:
+            start_idx = self.ofc_data.comp_dof_idx[comp]["startIdx"]
+            end_idx = (
+                self.ofc_data.comp_dof_idx[comp]["startIdx"]
+                + self.ofc_data.comp_dof_idx[comp]["idxLength"]
+            )
+
+            state0name = self.ofc_data.comp_dof_idx[comp]["state0name"]
+
+            if "Hexapod" in state0name:
+                self.dof_state0[start_idx:end_idx] = np.array(
+                    [
+                        self.ofc_data.dof_state0[state0name][axis_name]
+                        for axis_name in ["dZ", "dX", "dY", "rX", "rY"]
+                    ]
+                )
+            else:
+                self.dof_state0[start_idx:end_idx] = np.array(
+                    [
+                        self.ofc_data.dof_state0[state0name][f"mode{mode_idx+1}"]
+                        for mode_idx in range(
+                            self.ofc_data.comp_dof_idx[comp]["idxLength"]
+                        )
+                    ]
+                )
+
+        self.dof_state = self.dof_state0.copy()
+
+        # Initialize previous error and integral
+        self.previous_error = self.setpoint - self.dof_state0
+        self.integral = self.previous_error
+        self.filtered_derivative = np.zeros(len(self.ofc_data.dof_idx))
+
+        # Initialize PSSN data
+        self.pssn_data = dict(sensor_names=None, pssn=None)
+
+    @property
+    def kp(self) -> float:
+        """Proportional gain."""
+        return self._kp
+
+    @kp.setter
+    def kp(self, value: float) -> None:
+        self._kp = value
+
+    @property
+    def ki(self) -> float:
+        """Integral gain.
+
+        Returns
+        -------
+        `float`
+            Integral gain.
+        """
+        return self._ki
+
+    @ki.setter
+    def ki(self, value: float) -> None:
+        self._ki = value
+
+    @property
+    def kd(self) -> float:
+        """Derivative gain.
+
+        Returns
+        -------
+        `float`
+            Derivative gain.
+        """
+        return self._kd
+
+    @kd.setter
+    def kd(self, value: float) -> None:
+        self._kd = value
+
+    @property
+    def derivative_filter_coeff(self) -> float:
+        """Derivative filter coefficient.
+
+        Returns
+        -------
+        `float`
+            Derivative filter coefficient.
+        """
+        return self._derivative_filter_coeff
+
+    @derivative_filter_coeff.setter
+    def derivative_filter_coeff(self, value: float) -> None:
+        self._derivative_filter_coeff = value
+
+    def reset_dof_state(self) -> None:
+        """Initialize the state to the state 0 in the basis of degree of
+        freedom (DOF).
+        """
+        self.dof_state = self.dof_state0.copy()
+
+    def aggregate_state(
+        self, dof: np.ndarray | list, dof_idx: np.ndarray | list[int]
+    ) -> None:
+        """Aggregate the calculated degree of freedom (DOF) in the state.
+
+        Parameters
+        ----------
+        dof : `numpy.ndarray` or `list`
+            Calculated DOF.
+        dof_idx : `numpy.ndarray` or `list[int]`
+            Index array of degree of freedom.
+        """
+        self.dof_state[dof_idx] += dof
+
+    @property
+    def aggregated_state(self) -> np.ndarray:
+        """Returns the aggregated state.
+
+        Returns
+        -------
+        `np.ndarray`
+            Aggregated state.
+        """
+        return self.dof_state[self.ofc_data.dof_idx]
+
+    def reset_history(self) -> None:
+        """Reset the history of the controller."""
+        self.dof_state0 = self.dof_state.copy()
+        self.integral = (
+            self.setpoint[self.ofc_data.dof_idx] - self.dof_state[self.ofc_data.dof_idx]
+        )
+        self.previous_error = (
+            self.setpoint[self.ofc_data.dof_idx] - self.dof_state[self.ofc_data.dof_idx]
+        )
+        self.filtered_derivative = np.zeros(len(self.ofc_data.dof_idx))
+
+    def control_step(
+        self,
+        filter_name: str,
+        dof_state: np.ndarray,
+        sensor_names: list[str] | None = None,
+    ) -> np.ndarray:
+        """Estimate uk in the basis of degree of freedom (DOF).
+
+        Parameters
+        ----------
+        filter_name : `string`
+            Name of the filter.
+        dof_state : `numpy.ndarray`
+            Optical state in the basis of DOF.
+        sensor_names : `list` [`string`]
+            List of sensor names.
+
+        Raises
+        ------
+        NotImplementedError
+            Child class should implemented this.
+        """
+        raise NotImplementedError("Child class should implement this.")
+
+    def calculate_pid_step(self, state: np.ndarray) -> np.ndarray:
+        """
+        Calculate the control signal using PID controller.
+
+        Parameters
+        ----------
+        state : `np.ndarray`
+            State of the system.
+
+        Returns
+        -------
+        uk : `numpy.ndarray`
+            Calculated uk in the basis of DOF.
+        """
+        error = self.setpoint[self.ofc_data.dof_idx] - state
+        self.integral += error
+        derivative = error - self.previous_error
+
+        # Apply low-pass filter to the derivative term
+        self.filtered_derivative = (
+            self.derivative_filter_coeff * derivative
+            + (1 - self.derivative_filter_coeff) * self.filtered_derivative
+        )
+
+        uk = (
+            self.kp * error
+            + self.ki * self.integral
+            + self.kd * self.filtered_derivative
+        )
+
+        self.previous_error = error
+
+        return uk
+
+    def effective_fwhm_g4(self, pssn: np.ndarray, sensor_names: list[str]) -> float:
+        """Calculate the effective FWHM by Gaussian quadrature.
+
+        FWHM: Full width at half maximum.
+        FWHM = eta * FWHM_{atm} * sqrt(1/PSSN -1).
+        Effective GQFWHM = sum_{i} (w_{i}* FWHM_{i}).
+
+        Parameters
+        ----------
+        pssn : `numpy.ndarray` or `list`
+            Normalized point source sensitivity (PSSN).
+        sensor_names : `list` [`string`]
+            List of sensor names.
+
+        Returns
+        -------
+        `float`
+            Effective FWHM in arcsec by Gaussian quadrature.
+
+        Raises
+        ------
+        ValueError
+            Input values are unphysical.
+        ValueError
+            Image quality weights sum is zero. Please check your weights.
+        """
+
+        # Normalized image quality weight
+        imqw = [self.ofc_data.image_quality_weights[sensor] for sensor in sensor_names]
+
+        if np.sum(imqw) == 0:
+            raise ValueError(
+                "Image quality weights sum is zero. Please check your weights."
+            )
+
+        n_imqw = imqw / np.sum(imqw)
+
+        fwhm = self.ETA * self.FWHM_ATM * np.sqrt(1.0 / np.array(pssn) - 1.0)
+        fwhm_gq = np.sum(n_imqw * fwhm)
+
+        if np.isnan(fwhm_gq) or np.isinf(fwhm_gq):
+            raise ValueError("Input values are unphysical.")
+
+        return fwhm_gq
+
+    def fwhm_to_pssn(self, fwhm: np.ndarray) -> np.ndarray:
+        """Convert the FWHM data to PSSN.
+
+        Take the array of FWHM values (nominally 1 per CCD) and convert
+        it to PSSN (nominally 1 per CCD).
+
+        Parameters
+        ----------
+        fwhm : `numpy.ndarray[x]`
+            An array of FWHM values with sensor information.
+
+        Returns
+        -------
+        pssn : `numpy.ndarray[y]`
+            An array of PSSN values.
+        """
+
+        denominator = self.ETA * self.FWHM_ATM
+        pssn = 1.0 / ((fwhm / denominator) ** 2 + 1.0)
+
+        return pssn
+
+    def set_fwhm_data(self, fwhm: np.ndarray, sensor_names: list[str]) -> None:
+        """Set the list of FWHMSensorData of each CCD of camera.
+        Parameters
+        ----------
+        fwhm : `np.ndarray`
+            Array of arrays (e.g. 2-d array) which contains the FWHM data.
+            Each element contains an array of fwhm (in arcsec) measurements for
+            a  particular sensor.
+        sensor_names : `list` [`string`]
+            List of sensor names.
+        Raises
+        ------
+        RuntimeError
+            If size of `fwhm` and `sensor_names` are different.
+        """
+
+        if len(fwhm) != len(sensor_names):
+            raise RuntimeError(
+                f"Size of fwhm ({len(fwhm)}) is different than sensor_names ({len(sensor_names)})."
+            )
+
+        self.pssn_data["sensor_names"] = sensor_names.copy()
+        self.pssn_data["pssn"] = np.zeros(len(fwhm))
+
+        for s_id, fw in enumerate(fwhm):
+            self.pssn_data["pssn"][s_id] = np.average(self.fwhm_to_pssn(fwhm))

--- a/python/lsst/ts/ofc/controllers/oic_controller.py
+++ b/python/lsst/ts/ofc/controllers/oic_controller.py
@@ -19,212 +19,39 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__all__ = ["OICController"]
+
 import logging
 
 import numpy as np
 
-from . import BendModeToForce, SensitivityMatrix
+from .. import BendModeToForce, OFCData, SensitivityMatrix
+from . import BaseController
 
 
-class OFCController:
-    """Optical Feedback Control Controller.
+class OICController(BaseController):
+    """Optimal Integral Controller (OIC)"""
 
-    This class is mainly used to determine the offset (`uk`) of degree of
-    freedom (DOF) at time `k+1` based on the wavefront error (`yk`) at time
-    `k`.
-
-    Parameters
-    ----------
-    ofc_data : `OFCData`
-        Data container.
-    log : `logging.Logger` or `None`
-        Optional logging class to be used for logging operations. If `None`,
-        creates a new logger.
-
-    Attributes
-    ----------
-    dof_state : `np.array`
-        State of telescope in the basis of degrees of freedom.
-    dof_state0 : `np.array`
-        Initial state of telescope in the basis of degrees of freedom.
-    log : `logging.Logger`
-        Logger class used for logging operations.
-    m1m3_bmf : `BendModeToForce`
-        Class to convert bend mode to forces for M1M3.
-    m2_bmf : `BendModeToForce`
-        Class to convert bend mode to forces for M2.
-    ofc_data : `OFCData`
-        OFC data container.
-    """
-
-    # Eta in FWHM calculation.
-    ETA = 1.086
-
-    # FWHM in atmosphere.
-    FWHM_ATM = 0.6
-
-    def __init__(self, ofc_data, log=None):
-        if log is None:
-            self.log = logging.getLogger(type(self).__name__)
-        else:
-            self.log = log.getChild(type(self).__name__)
-
-        self.ofc_data = ofc_data
+    def __init__(self, ofc_data: OFCData, log: logging.Logger | None = None) -> None:
+        # Initialize base class
+        super().__init__(ofc_data, log)
 
         # Constuct the double zernike sensitivity matrix
         self.dz_sensitivity_matrix = SensitivityMatrix(self.ofc_data)
 
+        self.fwhm_threshold = 0.2
+        self.default_gain = 0.7
+
         self.m1m3_bmf = BendModeToForce("M1M3", self.ofc_data)
         self.m2_bmf = BendModeToForce("M2", self.ofc_data)
 
-        self._gain = 0
-
-        self.dof_state0 = np.zeros(len(self.ofc_data.dof_idx))
-
-        for comp in self.ofc_data.comp_dof_idx:
-            start_idx = self.ofc_data.comp_dof_idx[comp]["startIdx"]
-            end_idx = (
-                self.ofc_data.comp_dof_idx[comp]["startIdx"]
-                + self.ofc_data.comp_dof_idx[comp]["idxLength"]
-            )
-
-            state0name = self.ofc_data.comp_dof_idx[comp]["state0name"]
-
-            if "Hexapod" in state0name:
-                self.dof_state0[start_idx:end_idx] = np.array(
-                    [
-                        self.ofc_data.dof_state0[state0name][axis_name]
-                        for axis_name in ["dZ", "dX", "dY", "rX", "rY"]
-                    ]
-                )
-            else:
-                self.dof_state0[start_idx:end_idx] = np.array(
-                    [
-                        self.ofc_data.dof_state0[state0name][f"mode{mode_idx+1}"]
-                        for mode_idx in range(
-                            self.ofc_data.comp_dof_idx[comp]["idxLength"]
-                        )
-                    ]
-                )
-
-        self.dof_state = self.dof_state0.copy()
-
-    def reset_dof_state(self):
-        """Initialize the state to the state 0 in the basis of degree of
-        freedom (DOF).
-        """
-
-        self.dof_state = self.dof_state0.copy()
-
-    def aggregate_state(self, dof, dof_idx):
-        """Aggregate the calculated degree of freedom (DOF) in the state.
-
-        Parameters
-        ----------
-        dof : `numpy.ndarray` or `list`
-            Calculated DOF.
-        dof_idx : `numpy.ndarray` or `list` of `int`
-            Index array of degree of freedom.
-        """
-
-        self.dof_state[dof_idx] += dof
-
-    @property
-    def aggregated_state(self):
-        """Returns the aggregated state.
-
-        Returns
-        -------
-        `np.ndarray`
-            Aggregated state.
-        """
-        return self.dof_state[self.ofc_data.dof_idx]
-
-    @property
-    def gain(self):
-        """Get the gain value.
-
-        Returns
-        -------
-        gain : `float`
-            Gain value in the feedback.
-        """
-
-        return self._gain
-
-    @gain.setter
-    def gain(self, value):
-        """Set the gain value.
-
-        Parameters
-        ----------
-        value : `float`
-            Gain value in the feedback. It should be in the range of 0 and 1.
-
-        Raises
-        ------
-        ValueError
-            if value is not in the range of [0, 1].
-        """
-
-        if 0.0 <= value <= 1.0:
-            self._gain = value
-        else:
-            raise ValueError(f"Gain must be in the range of [0, 1]. Got {value}.")
-
-    def effective_fwhm_g4(self, pssn, sensor_names):
-        """Calculate the effective FWHM by Gaussian quadrature.
-
-        FWHM: Full width at half maximum.
-        FWHM = eta * FWHM_{atm} * sqrt(1/PSSN -1).
-        Effective GQFWHM = sum_{i} (w_{i}* FWHM_{i}).
-
-        Parameters
-        ----------
-        pssn : `numpy.ndarray` or `list`
-            Normalized point source sensitivity (PSSN).
-        sensor_names : `list` of `string`
-            List of sensor names.
-
-        Returns
-        -------
-        `float`
-            Effective FWHM in arcsec by Gaussian quadrature.
-
-        Raises
-        ------
-        ValueError
-            Input values are unphysical.
-        ValueError
-            Image quality weights sum is zero. Please check your weights.
-        """
-
-        # Normalized image quality weight
-        imqw = [self.ofc_data.image_quality_weights[sensor] for sensor in sensor_names]
-
-        if np.sum(imqw) == 0:
-            raise ValueError(
-                "Image quality weights sum is zero. Please check your weights."
-            )
-
-        n_imqw = imqw / np.sum(imqw)
-
-        fwhm = self.ETA * self.FWHM_ATM * np.sqrt(1.0 / np.array(pssn) - 1.0)
-        fwhm_gq = np.sum(n_imqw * fwhm)
-
-        if np.isnan(fwhm_gq) or np.isinf(fwhm_gq):
-            raise ValueError("Input values are unphysical.")
-
-        return fwhm_gq
-
-    def authority(self):
+    def authority(self) -> np.ndarray:
         """Compute the authority of the system.
 
         Returns
         -------
         authority : `np.array`
         """
-
         # Rigid Body Stroke - Authority
         rbs_authority = self.ofc_data.rb_stroke[0] / self.ofc_data.rb_stroke
 
@@ -242,7 +69,9 @@ class OFCController:
 
         return authority
 
-    def calc_uk_x00(self, mat_f, qx, mat_h):
+    def calc_uk_x00(
+        self, mat_f: np.ndarray, qx: np.ndarray, mat_h: np.ndarray
+    ) -> np.ndarray:
         """Calculate uk by referencing to "x00".
         The offset will only trace the relative changes of offset without
         regarding the real value.
@@ -254,6 +83,8 @@ class OFCController:
             Matrix F.
         qx : `numpy.ndarray`
             qx array.
+        mat_h : `numpy.ndarray`
+            Matrix H.
 
         Returns
         -------
@@ -270,7 +101,7 @@ class OFCController:
 
         return self.calc_uk_x0(mat_f=mat_f, qx=_qx)
 
-    def calc_uk_x0(self, mat_f, qx, **kwargs):
+    def calc_uk_x0(self, mat_f: np.ndarray, qx: np.ndarray, **kwargs) -> np.ndarray:
         """Calculate uk by referencing to "x0".
 
         The offset will only trace the previous one.
@@ -292,9 +123,11 @@ class OFCController:
         uk : `numpy.ndarray`
             Calculated uk in the basis of degree of freedom (DOF).
         """
-        return -mat_f.dot(qx)
+        return mat_f.dot(qx)
 
-    def calc_uk_0(self, mat_f, qx, mat_h):
+    def calc_uk_0(
+        self, mat_f: np.ndarray, qx: np.ndarray, mat_h: np.ndarray
+    ) -> np.ndarray:
         """Calculate uk by referencing to "0".
 
         The offset will trace the real value and target for 0.
@@ -321,42 +154,6 @@ class OFCController:
 
         return self.calc_uk_x0(mat_f=mat_f, qx=_qx)
 
-    def uk_gain(
-        self,
-        filter_name: str,
-        dof_state: np.ndarray,
-        sensor_names: list[str] | None = None,
-    ) -> np.ndarray:
-        """Estimate uk in the basis of degree of freedom (DOF) with gain
-        compensation.
-
-        Parameters
-        ----------
-        filter_name : `string`
-            Name of the filter.
-        dof_state : `numpy.ndarray`
-            Optical state in the basis of DOF.
-        sensor_names : `list` of `string`
-            List of sensor names.
-
-        Returns
-        -------
-        uk : `numpy.ndarray`
-            Calculated uk in the basis of DOF.
-
-        Raises
-        ------
-        RuntimeError
-            If `sensor_names` is not provided for full array mode instruments.
-        """
-
-        if (self.ofc_data.name != "lsst") and (sensor_names is None):
-            raise RuntimeError(
-                "sensor_names must be provided for full array mode instruments."
-            )
-
-        return self.gain * self.uk(filter_name, dof_state, sensor_names)
-
     def uk(
         self,
         filter_name: str,
@@ -375,7 +172,7 @@ class OFCController:
             Name of the filter.
         dof_state : `numpy.ndarray`
             Optical state in the basis of DOF.
-        sensor_names : `list` of `string`
+        sensor_names : `list` [`string`]
             List of sensor names.
 
         Returns
@@ -498,24 +295,70 @@ class OFCController:
 
         return uk.ravel()
 
-    def fwhm_to_pssn(self, fwhm):
-        """Convert the FWHM data to PSSN.
-
-        Take the array of FWHM values (nominally 1 per CCD) and convert
-        it to PSSN (nominally 1 per CCD).
+    def control_step(
+        self,
+        filter_name: str,
+        dof_state: np.ndarray,
+        sensor_names: list[str] | None = None,
+    ) -> np.ndarray:
+        """Estimate uk in the basis of degree of freedom (DOF) with gain
+        compensation.
 
         Parameters
         ----------
-        fwhm : `numpy.ndarray[x]`
-            An array of FWHM values with sensor information.
+        filter_name : `string`
+            Name of the filter.
+        dof_state : `numpy.ndarray`
+            Optical state in the basis of DOF.
+        sensor_names : `list` [`string`] or `None`
+            List of sensor names.
 
         Returns
         -------
-        pssn : `numpy.ndarray[y]`
-            An array of PSSN values.
+        control_effort : `numpy.ndarray`
+            Calculated uk in the basis of DOF.
+
+        Raises
+        ------
+        RuntimeError
+            If `sensor_names` is not provided for full array mode instruments.
         """
 
-        denominator = self.ETA * self.FWHM_ATM
-        pssn = 1.0 / ((fwhm / denominator) ** 2 + 1.0)
+        if (self.ofc_data.name != "lsst") and (sensor_names is None):
+            raise RuntimeError(
+                "sensor_names must be provided for full array mode instruments."
+            )
 
-        return pssn
+        correction = self.uk(filter_name, dof_state, sensor_names)
+
+        # Initialize the control effort with the proportional term
+        if self.kp < 0.0 or self.kp is None:
+            self.set_pssn_gain()
+
+        control_effort = self.calculate_pid_step(correction)
+
+        return control_effort
+
+    def set_pssn_gain(self) -> None:
+        """Set the gain value based on the PSSN, which comes from the FWHM by
+        DM team.
+
+        Raises
+        ------
+        RuntimeError
+            If `pssn_data` is not properly set.
+        """
+
+        if self.pssn_data["pssn"] is None or self.pssn_data["sensor_names"] is None:
+            raise RuntimeError(
+                "PSSN data not set. Run `set_fwhm_data` with appropriate data."
+            )
+
+        fwhm_gq = self.effective_fwhm_g4(
+            self.pssn_data["pssn"], self.pssn_data["sensor_names"]
+        )
+
+        if fwhm_gq > self.fwhm_threshold:
+            self.kp = 1.0
+        else:
+            self.kp = self.default_gain

--- a/python/lsst/ts/ofc/controllers/pid_controller.py
+++ b/python/lsst/ts/ofc/controllers/pid_controller.py
@@ -1,0 +1,56 @@
+# This file is part of ts_ofc.
+#
+# Developed for Vera Rubin Observatory.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+
+from . import BaseController
+
+__all__ = ["PIDController"]
+
+
+class PIDController(BaseController):
+    """PID controller."""
+
+    def control_step(
+        self,
+        filter_name: str,
+        dof_state: np.ndarray,
+        sensor_names: list[str] | None = None,
+    ) -> np.ndarray:
+        """Estimate the control offset for the given DOF state.
+
+        Parameters
+        ----------
+        filter_name : `string`
+            Name of the filter.
+        dof_state : `numpy.ndarray`
+            Optical state in the basis of DOF.
+        sensor_names : `list` [`string`]
+            List of sensor names.
+
+        Returns
+        -------
+        control_effort : `numpy.ndarray`
+            Calculated control_effort in the basis of DOF.
+        """
+        control_effort = self.calculate_pid_step(dof_state)
+
+        return control_effort

--- a/python/lsst/ts/ofc/ofc_data/base_ofc_data.py
+++ b/python/lsst/ts/ofc/ofc_data/base_ofc_data.py
@@ -65,16 +65,14 @@ class BaseOFCData:
     ----------
     alpha : `np.array` of `float`
         Alpha coefficient for the normalized point-source sensitivity (PSSN).
-    control_strategy : `string`
-        Name of the control strategy.
+    controller_filename : `string`
+        Name of the file where the controller is saved.
     dof_state0_filename : `string`
         Name of the file with the initial degrees of freedom.
     eff_wavelength : `dict` of `string`
         Effective wavelength in um for each filter.
     intrinsic_zk_filename_root : `string`
         Filename root string for the intrinsic zernike coefficients.
-    iqw_filename : `str`
-        Image quality weight filename.
     m1m3_actuator_penalty : `float`
         M1M3 actuator penalty factor.
     m2_actuator_penalty : `float`
@@ -89,15 +87,13 @@ class BaseOFCData:
         Filename root string for the sensitivity matrix M.
     y2_filename_root : `string`
         Name of the file where `y2_correction` is read from.
-    zn3_idx : `np.array` of `bool`
-        Index of annular Zernike polynomials (z3-z22) (`True`: in use, `False`:
-        not in use).
     znmax : `int`
-        Max number of zernikes used (to be filtered with `zn3_idx`).
+        Max number of zernikes used.
     znmin : `int`
-        Min number of zernikes used (to be filtered with `zn3_idx`).
+        Min number of zernikes used.
     """
 
+    # Filenames
     y2_filename_root: str = "_y2.yaml"
     dof_state0_filename: str = "state0_in_dof.yaml"
     intrinsic_zk_filename_root: str = "intrinsic_zk"
@@ -105,11 +101,9 @@ class BaseOFCData:
 
     eff_wavelength: dict = field(default_factory=default_eff_wavelenght)
 
+    # Used zernikes
     znmax: int = 28  # Max number of zernikes used (to be filtered with zn3Idx)
     znmin: int = 4  # Min number of zernikes used (to be filtered with zn3Idx)
-
-    # Control strategy
-    control_strategy: str = "optiPSSN"
 
     # M1M3 actuator penalty factor
     # how many microns of M2 piston does 1N rms force correspond to

--- a/tests/test_ofc_data.py
+++ b/tests/test_ofc_data.py
@@ -66,6 +66,14 @@ class TestOFCData(unittest.TestCase):
         with self.assertRaises(AttributeError):
             self.ofc_data.dof_idx = np.zeros_like(self.ofc_data.dof_idx)
 
+    def test_change_controller_configuration(self):
+        ofc_data = OFCData("lsst")
+        initial_kd = ofc_data.controller["kd"]
+
+        ofc_data.controller_filename = "pid_controller.yaml"
+
+        self.assertNotEqual(ofc_data.controller["kd"], initial_kd)
+
     def test_selected_zn_idx(self):
         self.assertTrue(isinstance(self.ofc_data.zn_selected, np.ndarray))
 

--- a/tests/test_oic_controller.py
+++ b/tests/test_oic_controller.py
@@ -22,25 +22,26 @@
 import unittest
 
 import numpy as np
-from lsst.ts.ofc import OFCController, OFCData
+from lsst.ts.ofc import OFCData, OICController
 
 
-class TestOFCController(unittest.TestCase):
-    """Test the OFCController class."""
+class TestOICController(unittest.TestCase):
+    """Test the OICController class."""
 
     def setUp(self):
         self.ofc_data = OFCData("lsst")
+
         # Set small motion penalty to allow for larger corrections
         self.ofc_data.motion_penalty = 0.00001
-        self.ofc_controller = OFCController(self.ofc_data)
+        self.controller = OICController(self.ofc_data)
 
         test_dof_state0 = np.zeros(50)
         test_dof_state0[15] = 0.5
         test_dof_state0[25] = 1.5
         test_dof_state0[45] = 1.5
 
-        self.ofc_controller.dof_state0 = test_dof_state0
-        self.ofc_controller.reset_dof_state()
+        self.controller.dof_state0 = test_dof_state0
+        self.controller.reset_dof_state()
 
         self.filter_name = "R"
 
@@ -49,9 +50,9 @@ class TestOFCController(unittest.TestCase):
 
         sum_uk = np.zeros(50)
         for _ in range(5):
-            uk = self.ofc_controller.uk(
+            uk = self.controller.uk(
                 self.filter_name,
-                self.ofc_controller.dof_state0 + sum_uk,
+                self.controller.dof_state0 - sum_uk,
             )
             sum_uk += uk
 
@@ -61,26 +62,26 @@ class TestOFCController(unittest.TestCase):
         # Check that corrections match original dof_state after three
         # iterations. Note that other degrees of freedom values are
         # not checked because degenerate solutions exist.
-        assert self.mean_squared_residual(-sum_uk[15], 0.5) < 5e-2
-        assert self.mean_squared_residual(-sum_uk[25], 1.5) < 5e-2
-        assert self.mean_squared_residual(-sum_uk[45], 1.5) < 5e-2
+        assert self.mean_squared_residual(sum_uk[15], 0.5) < 5e-2
+        assert self.mean_squared_residual(sum_uk[25], 1.5) < 5e-2
+        assert self.mean_squared_residual(sum_uk[45], 1.5) < 5e-2
 
     def mean_squared_residual(self, new_array, reference_array):
         return np.sum((new_array - reference_array) ** 2) / np.sum(reference_array**2)
 
     def test_uk_nogain_0(self):
         self.ofc_data.xref = "0"
-        uk = self.ofc_controller.uk(self.filter_name, self.ofc_controller.dof_state0)
+        uk = self.controller.uk(self.filter_name, self.controller.dof_state0)
 
         # Check length of correction vector matches used number of DOFs
         self.assertEqual(len(uk), len(self.ofc_data.dof_idx))
 
         # Check for ref "0" our corrections is minus the initial DOF state
-        assert self.mean_squared_residual(-uk, self.ofc_controller.dof_state0) < 1e-6
+        assert self.mean_squared_residual(uk, self.controller.dof_state0) < 1e-6
 
     def test_uk_nogain_x00(self):
         self.ofc_data.xref = "x00"
-        uk = self.ofc_controller.uk(self.filter_name, self.ofc_controller.dof_state0)
+        uk = self.controller.uk(self.filter_name, self.controller.dof_state0)
 
         # Check length of correction vector matches used number of DOFs
         self.assertEqual(len(uk), len(self.ofc_data.dof_idx))
@@ -88,28 +89,47 @@ class TestOFCController(unittest.TestCase):
         # Check for ref "x00" our corrections match the corrections
         # for x0, when dof_state = dof_state0
         self.ofc_data.xref = "x0"
-        uk_ref0 = self.ofc_controller.uk(
-            self.filter_name, self.ofc_controller.dof_state0
-        )
+        uk_ref0 = self.controller.uk(self.filter_name, self.controller.dof_state0)
 
         assert self.mean_squared_residual(uk_ref0, uk) < 1e-6
 
     def test_all_xref_ok(self):
         for xref in self.ofc_data.xref_list:
-            self.assertTrue(hasattr(self.ofc_controller, f"calc_uk_{xref}"))
-
-    def test_bad_gain(self):
-        with self.assertRaises(ValueError):
-            self.ofc_controller.gain = -0.5
-
-        with self.assertRaises(ValueError):
-            self.ofc_controller.gain = 1.5
+            self.assertTrue(hasattr(self.controller, f"calc_uk_{xref}"))
 
     def test_gain(self):
         for gain in {0.0, 0.25, 0.5, 0.75, 1.0}:
             with self.subTest(gain=gain):
-                self.ofc_controller.gain = gain
-                self.assertEqual(self.ofc_controller.gain, gain)
+                self.controller.kp = gain
+                self.assertEqual(self.controller.kp, gain)
+
+    def test_set_pssn_gain_unconfigured(self):
+        with self.assertRaises(RuntimeError):
+            self.controller.set_pssn_gain()
+
+    def test_set_pssn_gain(self):
+        fwhm_values = np.ones((4, 19)) * 0.2
+        sensor_names = ["R00_SW0", "R04_SW0", "R40_SW0", "R44_SW0"]
+
+        self.controller.set_fwhm_data(fwhm_values, sensor_names)
+
+        self.controller.set_pssn_gain()
+
+        self.assertTrue(self.controller.kp, self.controller.default_gain)
+
+        fwhm_values = np.ones((4, 19))
+
+        self.controller.set_fwhm_data(fwhm_values, sensor_names)
+
+        self.controller.set_pssn_gain()
+
+        self.assertTrue(self.controller.kp, 1.0)
+
+    def test_pssn_data(self):
+        self.assertTrue("sensor_names" in self.controller.pssn_data)
+        self.assertTrue("pssn" in self.controller.pssn_data)
+        self.assertTrue(self.controller.pssn_data["sensor_names"] is None)
+        self.assertTrue(self.controller.pssn_data["pssn"] is None)
 
 
 if __name__ == "__main__":

--- a/tests/test_pid_controller.py
+++ b/tests/test_pid_controller.py
@@ -1,0 +1,181 @@
+# This file is part of ts_ofc.
+#
+# Developed for Vera Rubin Observatory.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+import numpy as np
+from lsst.ts.ofc import OFCData, PIDController
+
+
+class TestPIDController(unittest.TestCase):
+    """Test the PIDController class."""
+
+    def setUp(self):
+        self.ofc_data = OFCData("lsst")
+        self.ofc_data.controller_filename = "pid_controller.yaml"
+        self.pid_controller = PIDController(self.ofc_data)
+        self.pid_controller.kp = 1.0
+        self.pid_controller.ki = 0.1
+        self.pid_controller.kd = 0.05
+        self.pid_controller.setpoint = np.ones(50)
+        self.pid_controller.previous_error = np.zeros(50)
+        self.pid_controller.integral = np.zeros(50)
+
+        self.filter_name = "R"
+        self.dof_state = np.ones(50)
+        self.dof_state[:10] = 0.5
+
+    def test_control_step_response(self):
+        """Test control outputs based on a simple input and PID settings."""
+        expected_uk = self.calculate_expected_uk(self.dof_state)
+
+        uk = self.pid_controller.control_step(self.filter_name, self.dof_state)
+
+        np.testing.assert_array_almost_equal(
+            uk,
+            expected_uk,
+            decimal=5,
+            err_msg="PID control output does not match expected values.",
+        )
+
+    def calculate_expected_uk(self, dof_state):
+        """Calculate expected control output for given DOF state."""
+        integral = self.pid_controller.integral.copy()
+        error = self.pid_controller.setpoint - dof_state
+        integral += error
+        derivative = error - self.pid_controller.previous_error
+        uk = (
+            self.pid_controller.kp * error
+            + self.pid_controller.ki * integral
+            + self.pid_controller.kd * derivative
+        )
+
+        return uk
+
+    def test_subset_of_dofs(self):
+        """Test control output for a subset of DOFs."""
+        new_comp_dof_idx = dict(
+            m2HexPos=np.zeros(5, dtype=bool),
+            camHexPos=np.ones(5, dtype=bool),
+            M1M3Bend=np.zeros(20, dtype=bool),
+            M2Bend=np.zeros(20, dtype=bool),
+        )
+
+        self.pid_controller.ofc_data.comp_dof_idx = new_comp_dof_idx
+        self.pid_controller.reset_history()
+
+        initial_state = 0.7 * np.ones(5)
+        uk = self.pid_controller.control_step(self.filter_name, initial_state)
+
+        self.assertEqual(len(uk), 5)
+
+    def test_reset_history(self):
+        """Test resetting the history of the controller."""
+        uk = self.pid_controller.control_step(self.filter_name, self.dof_state)
+        self.pid_controller.aggregate_state(uk, self.ofc_data.dof_idx)
+        self.pid_controller.control_step(self.filter_name, self.dof_state)
+
+        final_integral = self.pid_controller.integral.copy()
+        final_previous_error = self.pid_controller.previous_error.copy()
+
+        self.pid_controller.reset_history()
+
+        if id(self.pid_controller.dof_state0) == id(self.pid_controller.dof_state):
+            raise AssertionError("Initial DOF state not reset correctly.")
+
+        if np.array_equal(
+            self.pid_controller.integral,
+            final_integral,
+        ):
+            raise AssertionError("Integral history not reset correctly.")
+
+        if np.array_equal(
+            self.pid_controller.previous_error,
+            final_previous_error,
+        ):
+            raise AssertionError("Previous error not reset correctly.")
+
+        np.testing.assert_array_equal(
+            self.pid_controller.integral,
+            self.pid_controller.setpoint[self.pid_controller.ofc_data.dof_idx]
+            - self.pid_controller.dof_state[self.pid_controller.ofc_data.dof_idx],
+        )
+        np.testing.assert_array_equal(
+            self.pid_controller.previous_error,
+            self.pid_controller.setpoint[self.pid_controller.ofc_data.dof_idx]
+            - self.pid_controller.dof_state[self.pid_controller.ofc_data.dof_idx],
+        )
+
+    def test_derivative_filter(self):
+        """Test derivative filter."""
+        self.pid_controller.derivative_filter_coeff = 0.5
+        initial_state = 0.7 * np.ones(50)
+        self.pid_controller.control_step(self.filter_name, initial_state)
+        previous_derivative = self.pid_controller.filtered_derivative.copy()
+
+        # Change in error should reflect in derivative term
+        new_state = 0.8 * np.ones(50)
+        self.pid_controller.control_step(self.filter_name, new_state)
+
+        expected_derivative = 0.5 * (
+            (self.pid_controller.setpoint - new_state) - previous_derivative
+        )
+        np.testing.assert_array_equal(
+            self.pid_controller.filtered_derivative,
+            expected_derivative,
+            "Derivative calculation does not match expected.",
+        )
+
+    def test_integral_behavior(self):
+        """Test integral behavior over multiple steps."""
+        initial_state = 0.7 * np.ones(50)
+        self.pid_controller.control_step(self.filter_name, initial_state)
+        self.pid_controller.control_step(self.filter_name, initial_state)
+        # Check if integral is accumulating correctly
+        np.testing.assert_array_equal(
+            self.pid_controller.integral.squeeze(),
+            2 * (self.pid_controller.setpoint - initial_state),
+            "Integral not accumulating correctly.",
+        )
+
+    def test_derivative_behavior(self):
+        """Test derivative impact on control step."""
+        initial_state = 0.7 * np.ones(50)
+        self.pid_controller.control_step(self.filter_name, initial_state)
+
+        # Change in error should reflect in derivative term
+        new_state = 0.8 * np.ones(50)
+        self.pid_controller.control_step(self.filter_name, new_state)
+
+        expected_derivative = (self.pid_controller.setpoint - new_state) - (
+            self.pid_controller.setpoint - initial_state
+        )
+        np.testing.assert_array_equal(
+            self.pid_controller.previous_error
+            - (self.pid_controller.setpoint - initial_state),
+            expected_derivative,
+            "Derivative calculation does not match expected.",
+        )
+
+
+if __name__ == "__main__":
+    # Run the unit test
+    unittest.main()


### PR DESCRIPTION
This PR includes:
- Creates a directory of controller classes to be used by OFC. 
- Removes OFCController and substitutes it by OICController and PIDController
- These new controllers are configured through a yaml configuration file to tweak gains